### PR TITLE
Add tags to loggly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Container to send rsyslog to loggly
 
 ## Requirements
 * Environmental Variables:
+  * ENVIRONMENT
   * HOSTNAME
   * LOGGLY_TOKEN

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ config="/etc/rsyslog.conf"
 echo "Creating config file..."
 
 cat << EOF >> ${config}
-template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\" environment=\"${ENVIRONMENT}\"] %msg%\n")
+template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\" tag=\"${ENVIRONMENT}\"] %msg%\n")
 
 action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="514" template="LogglyFormat")
 

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ config="/etc/rsyslog.conf"
 echo "Creating config file..."
 
 cat << EOF >> ${config}
-template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\"] %msg%\n")
+template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\" tagtest=\"foobar\"] %msg%\n")
 
 action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="514" template="LogglyFormat")
 

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ config="/etc/rsyslog.conf"
 echo "Creating config file..."
 
 cat << EOF >> ${config}
-template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\" tagtest=\"foobar\"] %msg%\n")
+template(name="LogglyFormat" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% ${HOSTNAME} %app-name% %procid% %msgid% [${LOGGLY_TOKEN}@41058 tag=\"haproxy\" environment=\"${ENVIRONMENT}\"] %msg%\n")
 
 action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="514" template="LogglyFormat")
 


### PR DESCRIPTION
* this will add the `${ENVIRONMENT}` variable as a tag to the logging bits to loggly
* this variable will need to be added to whatever starts it, in our case, kubernetes will need a configuration that plops it in place
* The reason I'm using `tag=` is that loggly ignore the name of the tag.  If I had called it `environment=`, the word environment would not have made it to loggly, they only care about the value.
* So now when searching loggly we can do something like this: `tag:staging3 tag:haproxy` to get all of the haproxy logs for the staging3 environment
* If the `ENVIRONMENT` is not set, there simply won't be a tag show up for it in loggly
* connect waffleio/waffle.io-infrastructure#122